### PR TITLE
Using tf.contrib.losses.softmax_cross_entropy

### DIFF
--- a/yadlt/core/model.py
+++ b/yadlt/core/model.py
@@ -264,10 +264,7 @@ class Model(object):
                     (1 - ref_input) * tf.log(clip_sup))
 
             elif self.loss_func == 'softmax_cross_entropy':
-                softmax = tf.nn.softmax(model_output)
-                cost = - tf.reduce_mean(
-                    ref_input * tf.log(softmax) +
-                    (1 - ref_input) * tf.log(1 - softmax))
+                cost =  tf.softmax_cross_entropy_with_logits(model_output,ref_input)
 
             elif self.loss_func == 'mean_squared':
                 cost = tf.sqrt(tf.reduce_mean(

--- a/yadlt/core/model.py
+++ b/yadlt/core/model.py
@@ -243,7 +243,8 @@ class Model(object):
                                         (1 - ref_input) * tf.log(tf.clip_by_value(1 - model_output, 1e-10, float('inf'))))
 
             elif self.loss_func == 'softmax_cross_entropy':
-                cost = tf.nn.softmax_cross_entropy_with_logits(model_output,ref_input)
+                softmax = tf.nn.softmax(model_output)
+                cost = - tf.reduce_mean(ref_input * tf.log(softmax) + (1 - ref_input) * tf.log(1 - softmax))
 
             elif self.loss_func == 'mean_squared':
                 cost = tf.sqrt(tf.reduce_mean(tf.square(ref_input - model_output)))

--- a/yadlt/core/model.py
+++ b/yadlt/core/model.py
@@ -264,7 +264,7 @@ class Model(object):
                     (1 - ref_input) * tf.log(clip_sup))
 
             elif self.loss_func == 'softmax_cross_entropy':
-                cost =  tf.softmax_cross_entropy_with_logits(model_output,ref_input)
+                cost =  tf.contrib.losses.softmax_cross_entropy(model_output,ref_input)
 
             elif self.loss_func == 'mean_squared':
                 cost = tf.sqrt(tf.reduce_mean(

--- a/yadlt/core/model.py
+++ b/yadlt/core/model.py
@@ -243,8 +243,7 @@ class Model(object):
                                         (1 - ref_input) * tf.log(tf.clip_by_value(1 - model_output, 1e-10, float('inf'))))
 
             elif self.loss_func == 'softmax_cross_entropy':
-                softmax = tf.nn.softmax(model_output)
-                cost = - tf.reduce_mean(ref_input * tf.log(softmax) + (1 - ref_input) * tf.log(1 - softmax))
+                cost = tf.nn.softmax_cross_entropy_with_logits(model_output,ref_input)
 
             elif self.loss_func == 'mean_squared':
                 cost = tf.sqrt(tf.reduce_mean(tf.square(ref_input - model_output)))


### PR DESCRIPTION
tf.contrib.losses.softmax_cross_entropy avoid NA values during the training basically computes the cross entropy loss more carefully 