### PR TITLE
Fixed incorrect ordering of params in RBM._train_model function

### DIFF
--- a/yadlt/models/boltzmann/rbm.py
+++ b/yadlt/models/boltzmann/rbm.py
@@ -61,8 +61,8 @@ class RBM(UnsupervisedModel):
         self.hrand = None
         self.vrand = None
 
-    def _train_model(self, train_set, validation_set,
-                     train_ref=None, Validation_ref=None):
+    def _train_model(self, train_set, train_ref=None, validation_set=None,
+                      Validation_ref=None):
         """Train the model.
 
         :param train_set: training set


### PR DESCRIPTION
The way that the fit function of UnsupervisedModel feeds data to _train_model is inconsistent with the way _train_model of RBM receives data. So, I just reordered the RBM's _train_model parameters.

https://github.com/blackecho/Deep-Learning-TensorFlow/blob/master/yadlt/core/unsupervised_model.py#L30